### PR TITLE
Revert "Use Theia version 0.3.12"

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "node"
   ],
   "dependencies": {
-    "@theia/core": "0.3.12",
-    "@theia/plugin-ext": "0.3.12",
+    "@theia/core": "0.3.10",
+    "@theia/plugin-ext": "0.3.10",
     "@eclipse-che/workspace-client": "latest"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts eclipse/che-theia-hosted-plugin-manager-extension#2
We have broken hosted instance in Theia 0.3.12 release, so for now we will use old working image.