### PR TITLE
If WORKSPACE_ID is not available, then skip the logic 

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,23 +1,24 @@
 {
-    "compilerOptions": {
-        "strict": true,
-        "skipLibCheck": true,
-        "experimentalDecorators": true,
-        "noUnusedLocals": true,
-        "emitDecoratorMetadata": true,
-        "downlevelIteration": true,
-        "module": "commonjs",
-        "moduleResolution": "node",
-        "target": "es5",
-        "lib": [
-            "es6",
-            "dom"
-        ],
-        "sourceMap": true,
-        "rootDir": "src",
-        "outDir": "lib"
-    },
-    "include": [
-        "src"
-    ]
+  "compilerOptions": {
+    "strict": true,
+    "skipLibCheck": true,
+    "experimentalDecorators": true,
+    "noUnusedLocals": true,
+    "emitDecoratorMetadata": true,
+    "downlevelIteration": true,
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "strictPropertyInitialization": false,
+    "target": "es5",
+    "lib": [
+      "es6",
+      "dom"
+    ],
+    "sourceMap": true,
+    "rootDir": "src",
+    "outDir": "lib"
+  },
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
Do not update the process URI if not running inside Che

It will allow to test 'hosted' mode in pure docker env


note: add `"strictPropertyInitialization": false` so we can use `@inject` on a private field for the logger.